### PR TITLE
refactor preloader, support has_many through belongs_to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea
+.tool-versions

--- a/eager_group.gemspec
+++ b/eager_group.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'pry'
 end

--- a/lib/active_record/with_eager_group.rb
+++ b/lib/active_record/with_eager_group.rb
@@ -9,7 +9,9 @@ module ActiveRecord
     end
 
     def eager_group(*args)
-      check_if_method_has_arguments!('eager_group', args)
+      raise ArgumentError, "The method .eager_group() must contain arguments." if args.blank?
+      args.compact_blank!
+
       spawn.eager_group!(*args)
     end
 
@@ -27,5 +29,8 @@ module ActiveRecord
 
       @values[:eager_group] = values
     end
+
+    private
+
   end
 end

--- a/lib/eager_group/preloader/aggregation_finder.rb
+++ b/lib/eager_group/preloader/aggregation_finder.rb
@@ -1,0 +1,33 @@
+module EagerGroup
+  class Preloader
+    class AggregationFinder
+      attr_reader :klass, :reflection, :definition, :arguments, :record_ids
+
+      def initialize(klass, definition, arguments, records)
+        @klass = klass
+        @definition = definition
+        @reflection = @klass.reflect_on_association(definition.association)
+        @arguments = arguments
+        @records = records
+      end
+
+      def definition_scope
+        reflection.klass.instance_exec(*arguments, &definition.scope) if definition.scope
+      end
+
+      def record_ids
+        @record_ids ||= @records.map { |record| record.send(group_by_key) }
+      end
+
+      def group_by_key
+        @klass.primary_key
+      end
+
+      private
+
+      def polymophic_as_condition
+        reflection.type ? { reflection.name => { reflection.type => @klass.base_class.name } } : []
+      end
+    end
+  end
+end

--- a/lib/eager_group/preloader/has_many.rb
+++ b/lib/eager_group/preloader/has_many.rb
@@ -1,0 +1,18 @@
+module EagerGroup
+  class Preloader
+    class HasMany < AggregationFinder
+      def group_by_foreign_key
+        reflection.foreign_key
+      end
+
+      def aggregate_hash
+        scope = reflection.klass.all.tap{|query| query.merge!(definition_scope) if definition_scope }
+
+        scope.where(group_by_foreign_key => record_ids).
+          where(polymophic_as_condition).
+          group(group_by_foreign_key).
+          send(definition.aggregation_function, definition.column_name)
+      end
+    end
+  end
+end

--- a/lib/eager_group/preloader/has_many_through_belongs_to.rb
+++ b/lib/eager_group/preloader/has_many_through_belongs_to.rb
@@ -1,0 +1,26 @@
+module EagerGroup
+  class Preloader
+    class HasManyThroughBelongsTo < AggregationFinder
+      def group_by_foreign_key
+        "#{reflection.table_name}.#{reflection.through_reflection.klass.reflect_on_association(reflection.name).foreign_key}"
+      end
+
+      def aggregate_hash
+        scope = reflection.klass.all.tap{|query| query.merge!(definition_scope) if definition_scope }
+
+        scope.where(group_by_foreign_key => record_ids).
+          where(polymophic_as_condition).
+          group(group_by_foreign_key).
+          send(definition.aggregation_function, definition.column_name)
+      end
+
+      def group_by_key
+        reflection.through_reflection.foreign_key
+      end
+
+      def polymophic_as_condition
+        reflection.type ? { reflection.name => { reflection.type => reflection.through_reflection.klass.base_class.name } } : []
+      end
+    end
+  end
+end

--- a/lib/eager_group/preloader/has_many_through_many.rb
+++ b/lib/eager_group/preloader/has_many_through_many.rb
@@ -1,0 +1,18 @@
+module EagerGroup
+  class Preloader
+    class HasManyThroughMany < AggregationFinder
+      def group_by_foreign_key
+        "#{reflection.through_reflection.name}.#{reflection.through_reflection.foreign_key}"
+      end
+
+      def aggregate_hash
+        scope = klass.joins(reflection.name).tap{|query| query.merge!(definition_scope) if definition_scope }
+
+        scope.where(group_by_foreign_key => record_ids).
+          where(polymophic_as_condition).
+          group(group_by_foreign_key).
+          send(definition.aggregation_function, definition.column_name)
+      end
+    end
+  end
+end

--- a/lib/eager_group/preloader/many_to_many.rb
+++ b/lib/eager_group/preloader/many_to_many.rb
@@ -1,0 +1,18 @@
+module EagerGroup
+  class Preloader
+    class ManyToMany < AggregationFinder
+      def group_by_foreign_key
+        "#{reflection.join_table}.#{reflection.foreign_key}"
+      end
+
+      def aggregate_hash
+        scope = klass.joins(reflection.name).tap{|query| query.merge!(definition_scope) if definition_scope}
+
+        scope.where(group_by_foreign_key => record_ids).
+          where(polymophic_as_condition).
+          group(group_by_foreign_key).
+          send(definition.aggregation_function, definition.column_name)
+      end
+    end
+  end
+end

--- a/spec/integration/eager_group_spec.rb
+++ b/spec/integration/eager_group_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe EagerGroup, type: :model do
 
       it 'gets Post#comments_average_rating and Post#comments_average_rating from users' do
         users = User.includes(:posts).eager_group(posts: %i[approved_comments_count comments_average_rating])
+
         expect(users[0].posts[0].approved_comments_count).to eq 1
         expect(users[0].posts[0].comments_average_rating).to eq 3
         expect(users[1].posts[0].approved_comments_count).to eq 2
@@ -80,7 +81,7 @@ RSpec.describe EagerGroup, type: :model do
       end
     end
 
-    context 'has_many :through' do
+    context 'has_many :through many' do
       it 'gets Student#posts_count' do
         students = Student.eager_group(:posts_count)
         expect(students[0].posts_count).to eq 2
@@ -92,6 +93,14 @@ RSpec.describe EagerGroup, type: :model do
         users = User.eager_group(:comments_count)
         expect(users[0].comments_count).to eq 3
         expect(users[1].comments_count).to eq 2
+      end
+    end
+
+    context 'has_many :through belongs to' do
+      it 'gets Homework#student_comments_count' do
+        homeworks = Homework.eager_group(:student_comments_count)
+        expect(homeworks[0].student_comments_count).to eq(3)
+        expect(homeworks[1].student_comments_count).to eq(1)
       end
     end
   end
@@ -181,6 +190,7 @@ RSpec.describe EagerGroup, type: :model do
         expect(students[1].posts_count).to eq 1
         expect(students[2].posts_count).to eq 0
       end
+
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,10 +20,12 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'eager_group'
+require 'pry'
 
 load 'support/schema.rb'
 load 'support/models.rb'
 load 'support/data.rb'
+
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/data.rb
+++ b/spec/support/data.rb
@@ -23,3 +23,6 @@ post1.comments.create(status: 'deleted', rating: 0, author: student2)
 
 post2.comments.create(status: 'approved', rating: 3, author: student1)
 post2.comments.create(status: 'approved', rating: 5, author: teacher1)
+
+homework1 = Homework.create(student: student1, teacher: teacher1)
+homework1 = Homework.create(student: student2, teacher: teacher1)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -50,5 +50,10 @@ class Homework < ActiveRecord::Base
   belongs_to :teacher
   belongs_to :student
 
+  has_many :comments, through: :student
+
   define_eager_group :students_count, :students, :count, '*'
+  define_eager_group :student_comments_count, :comments, :count, '*'
 end
+
+ActiveRecord::Base.logger = Logger.new(STDOUT)


### PR DESCRIPTION
# Change log
- Split preloader logic, case by case based on association type
- Support eager group on has_many through belongs_to associations
- Fix bug, do not flatten eager_group arguments, Allow `eager_group([:definition_2, argument1, argument2])`
- Support preload multiple eager_group from association e.g.` eager_group(posts: [:approved_comments_count, :comments_average_rating])`