### PR TITLE
Bugfix: load multiple different type eager_group_values

### DIFF
--- a/lib/active_record/with_eager_group.rb
+++ b/lib/active_record/with_eager_group.rb
@@ -9,8 +9,7 @@ module ActiveRecord
     end
 
     def eager_group(*args)
-      raise ArgumentError, "The method .eager_group() must contain arguments." if args.blank?
-      args.compact_blank!
+      check_argument_not_blank!(args)
 
       spawn.eager_group!(*args)
     end
@@ -28,6 +27,13 @@ module ActiveRecord
       raise ImmutableRelation if @loaded
 
       @values[:eager_group] = values
+    end
+
+    private
+
+    def check_argument_not_blank!(args)
+      raise ArgumentError, "The method .eager_group() must contain arguments." if args.blank?
+      args.compact_blank!
     end
   end
 end

--- a/lib/active_record/with_eager_group.rb
+++ b/lib/active_record/with_eager_group.rb
@@ -9,7 +9,8 @@ module ActiveRecord
     end
 
     def eager_group(*args)
-      check_if_method_has_arguments!(__callee__, args)
+      raise ArgumentError, "The method .eager_group() must contain arguments." if args.blank?
+      args.compact_blank!
 
       spawn.eager_group!(*args)
     end

--- a/lib/eager_group.rb
+++ b/lib/eager_group.rb
@@ -40,7 +40,7 @@ module EagerGroup
   private
 
   def preload_eager_group(*eager_group_value)
-    EagerGroup::Preloader.new(self.class, [self], eager_group_value).run
+    EagerGroup::Preloader.new(self.class, [self], [eager_group_value]).run
   end
 end
 

--- a/lib/eager_group/preloader.rb
+++ b/lib/eager_group/preloader.rb
@@ -11,8 +11,7 @@ module EagerGroup
     def initialize(klass, records, eager_group_values)
       @klass = klass
       @records = Array.wrap(records).compact.uniq
-      eager_group_definitions = @klass.eager_group_definitions
-      @eager_group_values = eager_group_values.all? { |value| eager_group_definitions.key?(value) } ? eager_group_values : [eager_group_values]
+      @eager_group_values = eager_group_values
     end
 
     # Preload aggregate functions
@@ -27,11 +26,10 @@ module EagerGroup
           next if @records.empty?
 
           @klass = @records.first.class
+          self.class.new(@klass, @records, Array.wrap(definition_key)).run
         end
 
-        Array.wrap(definition_key).each do |key|
-          find_aggregate_values_per_definition!(key, arguments)
-        end
+        find_aggregate_values_per_definition!(definition_key, arguments)
       end
     end
 

--- a/lib/eager_group/preloader/aggregation_finder.rb
+++ b/lib/eager_group/preloader/aggregation_finder.rb
@@ -25,6 +25,10 @@ module EagerGroup
         @klass.primary_key
       end
 
+      def aggregate_hash
+        raise NotImplementedError, 'Method "aggregate_hash" must be implemented in subclass'
+      end
+
       private
 
       def polymophic_as_condition

--- a/spec/integration/eager_group_spec.rb
+++ b/spec/integration/eager_group_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe EagerGroup, type: :model do
         expect(posts[1].comments_average_rating_by_author).to eq 3
       end
 
+      it 'eager_group multiple different type of aggregate definitions' do
+        students = Student.all
+        posts = Post.eager_group(:approved_comments_count, [:comments_average_rating_by_author, students[0], true])
+        #comments_average_rating_by_author
+        expect(posts[0].comments_average_rating_by_author).to eq 4.5
+        expect(posts[1].comments_average_rating_by_author).to eq 3
+        # approved_comments_count
+        expect(posts[0].approved_comments_count).to eq 1
+        expect(posts[1].approved_comments_count).to eq 2
+        expect(posts[2].approved_comments_count).to eq 0
+      end
+
       it 'gets Post#comments_average_rating from users' do
         users = User.includes(:posts).eager_group(posts: :comments_average_rating)
         expect(users[0].posts[0].comments_average_rating).to eq 3


### PR DESCRIPTION
# Goals
- Support `eager_group` with different type of values together

`Model.eager_group(:definition_1, [:definition_2, scope_arg1, scope_arg2], {associated_resources: [:definition_3, [:definition_4, scope_arg1]]})`


# Change log
- Trade off by giving up supporting `Model.eager_group([:definition1, :definition2])` pattern
- Querying multiple different type of eager_group definitions in one line of code